### PR TITLE
Add Home URL and Source Code URL

### DIFF
--- a/src/orb.yml
+++ b/src/orb.yml
@@ -5,6 +5,10 @@ description: |
   The orb includes several commands you can run during your build to enforce your policy.
   For more information check here - https://docs.datree.io/docs/datree-and-circleci
 
+display:
+  source_url: https://github.com/datreeio/datree-orb
+  home_url: https://datree.io
+
 commands:
   branch-name-convention:
     description: |


### PR DESCRIPTION
Display a link to your home page and the orb source natively in the Orb registry as a clickable link.